### PR TITLE
Remove leading dollar signs in code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This project uses gitflow. To create a release, first start the release branch f
 which you want to release:
 
 ```console
-$ git flow release start 1.16.4
+git flow release start 1.16.4
 ```
 
 Perform any release related changes. At the very least, this means updating the current tag given in
@@ -41,14 +41,14 @@ Perform any release related changes. At the very least, this means updating the 
 Now, publish the release:
 
 ```console
-$ git flow release publish
+git flow release publish
 ```
 
 This will push the branch to GitHub and trigger a run of CI. Once CI is complete and all tests have
 passed, finish the release and push the tag to GitHub:
 
 ```console
-$ git flow release finish --push --tag
+git flow release finish --push --tag
 ```
 
 ## License


### PR DESCRIPTION
The dollar signs are unnecessary and should not be included.

https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md014---dollar-signs-used-before-commands-without-showing-output

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works

