### PR TITLE
Mark prettier as real dependency instead of devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/PicturePipe/docker-prettier/issues"
   },
   "homepage": "https://github.com/PicturePipe/docker-prettier#readme",
-  "devDependencies": {
+  "dependencies": {
     "prettier": "1.17.0"
   }
 }


### PR DESCRIPTION
As prettier is the main component of this Docker image, it should be
tracked as dependency and not as devDependency.

One reason for this is that Renovate will automatically merge newer
Prettier versions if the checks pass, but it won't take care to release
an updated Docker image.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
