### PR TITLE
Ensure our Alpine installation is up to date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ ENV NODE_DIR /home/node/node_modules/app
 ENV PATH $PATH:$NODE_DIR/node_modules/.bin
 
 # Install git and openssh-client for CircleCI
-RUN apk add \
+RUN apk upgrade \
+    --no-cache \
+    --no-progress \
+    --update \
+    && apk add \
     --no-cache \
     --no-progress \
     --update \


### PR DESCRIPTION
There is a known issue in the musl version which is shipped with the node image we are installing.

Alpine is shipping a newer version already though, so let's upgrade.